### PR TITLE
Fix dangling ndarray when a cv::Mat is cast with rv_policy::automatic_reference

### DIFF
--- a/cvnp_nano/cvnp_nano.h
+++ b/cvnp_nano/cvnp_nano.h
@@ -70,10 +70,14 @@ struct type_caster<cv::Mat>
         try
         {
             // Set default policies if automatic
-            if (policy == rv_policy::automatic)
+            // Note: automatic_reference must *not* be lowered to reference here.
+            // It is the policy used by nanobind::cast(), and hence by list::append(),
+            // dict assignment, etc. Those call sites pass a cv::Mat which is often a local
+            // variable, and they pass no cleanup_list either. Lowering the policy to
+            // reference would hand Python an ndarray without any owner, i.e. a view on
+            // memory that is freed as soon as the caller returns.
+            if (policy == rv_policy::automatic || policy == rv_policy::automatic_reference)
                 policy = rv_policy::copy;
-            else if (policy == rv_policy::automatic_reference)
-                policy = rv_policy::reference;
 
             // Exported ndarray
             ndarray<> a;

--- a/example/cvnp_nano_example.cpp
+++ b/example/cvnp_nano_example.cpp
@@ -127,6 +127,52 @@ cv::Mat ShortLivedMat()
 }
 
 
+// The same short lived Mat as ShortLivedMat(), handed to Python through the containers and
+// casts that user code commonly uses. Each of them picks its own rv_policy (see below), so
+// they exercise different branches of the cv::Mat caster than a returned cv::Mat does.
+static cv::Mat MakeShortLivedMat()
+{
+    auto mat = cv::Mat(cv::Size(300, 200), CV_8UC4);
+    mat = cv::Scalar(12, 34, 56, 78);
+    return mat;
+}
+
+// list::append() casts with rv_policy::automatic_reference, and passes no cleanup_list
+nanobind::list ShortLivedMatInList()
+{
+    nanobind::list result;
+    result.append(MakeShortLivedMat());
+    return result;
+}
+
+// make_tuple() casts with rv_policy::automatic, and passes no cleanup_list
+nanobind::tuple ShortLivedMatInTuple()
+{
+    return nanobind::make_tuple(MakeShortLivedMat());
+}
+
+// dict item assignment casts with rv_policy::automatic_reference
+nanobind::dict ShortLivedMatInDict()
+{
+    nanobind::dict result;
+    result["mat"] = MakeShortLivedMat();
+    return result;
+}
+
+// nanobind::cast() defaults to rv_policy::automatic_reference
+nanobind::object ShortLivedMatCast()
+{
+    return nanobind::cast(MakeShortLivedMat());
+}
+
+// The std::vector caster forwards the policy of the returned value (rv_policy::automatic)
+// to each element
+std::vector<cv::Mat> ShortLivedMatVector()
+{
+    return { MakeShortLivedMat() };
+}
+
+
 cv::Matx33d make_eye()
 {
     return cv::Matx33d::eye();
@@ -378,6 +424,11 @@ NB_MODULE(cvnp_nano_example, m)
 
     m.def("short_lived_matx", ShortLivedMatx);
     m.def("short_lived_mat", ShortLivedMat);
+    m.def("short_lived_mat_in_list", ShortLivedMatInList);
+    m.def("short_lived_mat_in_tuple", ShortLivedMatInTuple);
+    m.def("short_lived_mat_in_dict", ShortLivedMatInDict);
+    m.def("short_lived_mat_cast", ShortLivedMatCast);
+    m.def("short_lived_mat_vector", ShortLivedMatVector);
     m.def("RoundTripMatx21d", RoundTripMatx21d);
 
     // Multidimensional array functions

--- a/tests/test_cvnp_nano.py
+++ b/tests/test_cvnp_nano.py
@@ -348,6 +348,67 @@ def test_short_lived_mat():
     assert (m[0, 0] == (12, 34, 56, 78)).all()
 
 
+def test_short_lived_mat_in_containers():
+    """
+    Same short lived cv::Mat as in test_short_lived_mat(), but handed to Python through the
+    containers and casts that user code commonly uses. Each of them picks its own rv_policy,
+    so each exercises a different branch of the cv::Mat caster:
+
+        list.append(mat)      -> rv_policy::automatic_reference, and no cleanup_list
+        make_tuple(mat)       -> rv_policy::automatic, and no cleanup_list
+        dict["mat"] = mat     -> rv_policy::automatic_reference
+        nanobind::cast(mat)   -> rv_policy::automatic_reference
+        std::vector<cv::Mat>  -> the element inherits the policy of the returned value
+
+    Whichever the path, the ndarray handed to Python must own its data: the cv::Mat it came
+    from is a local variable, destroyed before Python ever sees the result.
+
+    Every path is measured and printed as a summary table *before* anything is asserted, so
+    that running this test on its own tells you which paths are affected and which are not
+    (pytest shows the table under "Captured stdout" when the test fails).
+    """
+    from cvnp_nano_example import (  # type: ignore
+        short_lived_mat_in_list, short_lived_mat_in_tuple, short_lived_mat_in_dict,
+        short_lived_mat_cast, short_lived_mat_vector,
+    )
+
+    # (path, the rv_policy that path uses, the array it handed to Python)
+    paths = [
+        ("return cv::Mat", "automatic", short_lived_mat()),
+        ("list.append", "automatic_reference", short_lived_mat_in_list()[0]),
+        ("make_tuple", "automatic", short_lived_mat_in_tuple()[0]),
+        ('dict["mat"] =', "automatic_reference", short_lived_mat_in_dict()["mat"]),
+        ("nanobind::cast", "automatic_reference", short_lived_mat_cast()),
+        ("std::vector<cv::Mat>", "automatic", short_lived_mat_vector()[0]),
+    ]
+    # Reuse the freed memory, so that a dangling view reads overwritten bytes.
+    # Without this, comparing the values often succeeds by accident: freed memory is
+    # usually still intact, which is why such a bug shows up only intermittently.
+    junk = [np.full(4096, 7, dtype=np.uint8) for _ in range(64)]  # noqa: F841
+
+    print("\n    Short lived cv::Mat handed to Python: does the ndarray own its data?\n")
+    print(f"    {'path':22s} {'rv_policy':21s} {'OWNDATA':8s} {'values':8s} verdict")
+    print(f"    {'-' * 22} {'-' * 21} {'-' * 8} {'-' * 8} {'-' * 13}")
+    dangling = []
+    for path, policy, m in paths:
+        owns_data = bool(m.flags["OWNDATA"])
+        values_ok = bool((m[0, 0] == (12, 34, 56, 78)).all())
+        verdict = "safe" if owns_data else "DANGLING VIEW"
+        print(f"    {path:22s} {policy:21s} {str(owns_data):8s} "
+              f"{'ok' if values_ok else 'garbage':8s} {verdict}")
+        if not (owns_data and values_ok):
+            dangling.append(path)
+    print()
+
+    bad_shape = [path for path, _, m in paths if m.shape != (200, 300, 4)]
+    assert not bad_shape, f"unexpected shape for: {', '.join(bad_shape)}"
+
+    assert not dangling, (
+        f"{len(dangling)} of {len(paths)} paths hand Python a view on freed memory "
+        f"(see the table above): {', '.join(dangling)}"
+    )
+
+
 def test_empty_mat():
     m = np.zeros(shape=(0, 0, 3))
     m2 = cvnp_roundtrip(m)
@@ -1436,6 +1497,7 @@ def main():
     test_point()
     test_cvnp_round_trip()
     test_short_lived_mat()
+    test_short_lived_mat_in_containers()
     test_empty_mat()
 
     test_additional_ref()


### PR DESCRIPTION
## The problem

`type_caster<cv::Mat>::from_cpp` lowers `rv_policy::automatic_reference` to `rv_policy::reference`:

```cpp
if (policy == rv_policy::automatic)
    policy = rv_policy::copy;
else if (policy == rv_policy::automatic_reference)
    policy = rv_policy::reference;        // <-- this line
```

The `reference` branch builds the ndarray with an empty owner (`mat_to_nparray(mat, no_owner)`) and hands that lowered policy on to `ndarray_export()`. That defeats a safety net nanobind provides on its own: `ndarray_export()` treats `automatic` and `automatic_reference` alike and copies the data when the ndarray has no owner, whereas `reference` falls into the `default:` case where `copy = false` (`src/nb_ndarray.cpp`).

`automatic_reference` is not a dangerous policy in itself. It is simply what `nanobind::cast()` defaults to, and hence what `list::append()`, `list::insert()` and dict item assignment use (`nb_cast.h`). Those call sites also pass `cleanup_list == nullptr`, so the keep-alive branch of `ndarray_export()` cannot help either. What Python receives has **no owner and no keep-alive**: a view on memory that is freed as soon as the caller returns.

This was found downstream, in a project vendoring this header. A function returning local `cv::Mat`s inside a `nb::list` produced numpy arrays with `owndata=False`, `base=memoryview`, and values that differed on every call. The same test passed or failed from run to run, depending on whether the freed memory had been reused yet.

## Why the existing tests did not catch it

`test_short_lived_mat()` covers exactly this lifetime question, but `ShortLivedMat()` *returns* a `cv::Mat`, so its policy is `automatic`, which the caster raises to `copy` — safe. No binding in `example/` used `nb::list` or `.append`, so the `automatic_reference` paths were never exercised at all.

## The fix

Treat `automatic_reference` like `automatic`, i.e. `copy`. That makes these paths as safe as returning a `cv::Mat` already was.

`reference_internal` is deliberately left untouched. It is not lowered, so nanobind attaches `cleanup->self()` as the owner, and that is what lets `def_rw` / `def_ro` properties keep sharing memory with the C++ `cv::Mat` — `test_mat_shared()` relies on that sharing, and raising the policy there would break it.

## Checking it without applying the fix

The new test hands the same short lived `cv::Mat` to Python through six paths, and prints what each one produced **before** asserting anything. So you can reproduce the problem yourself without trusting the caster change: take `test_short_lived_mat_in_containers()` plus the fixtures it uses in `example/cvnp_nano_example.cpp` onto unpatched code, and you get

```
    Short lived cv::Mat handed to Python: does the ndarray own its data?

    path                   rv_policy             OWNDATA  values   verdict
    ---------------------- --------------------- -------- -------- -------------
    return cv::Mat         automatic             True     ok       safe
    list.append            automatic_reference   False    garbage  DANGLING VIEW
    make_tuple             automatic             True     ok       safe
    dict["mat"] =          automatic_reference   False    garbage  DANGLING VIEW
    nanobind::cast         automatic_reference   False    garbage  DANGLING VIEW
    std::vector<cv::Mat>   automatic             True     ok       safe

E   AssertionError: 3 of 6 paths hand Python a view on freed memory
```

With the fix, all six report `safe`.

Note which paths are affected: only those going through `nanobind::cast()`. `make_tuple()` uses `automatic` (its own template default) and the `std::vector` caster forwards the policy of the returned value, so both were already safe. The dividing line is not "list versus tuple" but whether the call site goes through `cast()`.

`OWNDATA` is the deterministic check. Comparing the values alone passes by accident most of the time, which is why the test churns the heap before reading.

## Verified with

nanobind 2.13.0, OpenCV 4.12.0, Python 3.10, MSVC 19.44 (Windows). Full suite: 41 passed, both via `pytest tests/` and via `python tests/test_cvnp_nano.py` as the CI does.

## Side note, not addressed here

While measuring the above, `np.shares_memory()` shows that arrays leaving the caster never share memory with the C++ `cv::Mat`: `ndarray_export()` copies unconditionally under the `copy` policy. So the comment in the `copy` branch ("the python numpy array and the C++ cv::Mat will share the same data") does not describe what actually happens, and the heap `cv::Mat` plus capsule that branch allocates is redundant. Passing the *original* policy to `ndarray_export()` would avoid the copy, since the capsule already guarantees the lifetime — but it would also remove the copy that currently makes non-owning `cv::Mat`s (those wrapping an external buffer, `cv::Mat(rows, cols, type, ptr)`) safe by accident. That trade-off is out of scope for this PR; happy to open a separate issue if you want to pursue it.
